### PR TITLE
fix programmatically setting the label background

### DIFF
--- a/library/src/main/java/jahirfiquitiva/libs/fabsmenu/LabelView.java
+++ b/library/src/main/java/jahirfiquitiva/libs/fabsmenu/LabelView.java
@@ -90,12 +90,17 @@ public class LabelView extends CardView {
     }
 
     public void setTextColor(@ColorInt int color) {
-        this.textColor = color;
+        textColor = color;
         content.setTextColor(color);
     }
 
     public void setTextColorFromRes(@ColorRes int color) {
         setTextColor(ContextCompat.getColor(getContext(), color));
+    }
+
+    public void setBackgroundColor(@ColorInt int backgroundColor) {
+        rightBackgroundColor = backgroundColor;
+        setCardBackgroundColor(0);
     }
 
     @Override

--- a/library/src/main/java/jahirfiquitiva/libs/fabsmenu/TitleFAB.java
+++ b/library/src/main/java/jahirfiquitiva/libs/fabsmenu/TitleFAB.java
@@ -151,8 +151,8 @@ public class TitleFAB extends FloatingActionButton {
     public void setTitleBackgroundColor(@ColorInt int titleBackgroundColor) {
         this.titleBackgroundColor = titleBackgroundColor;
         LabelView label = getLabelView();
-        if (label != null && label.getContent() != null) {
-            label.getContent().setBackgroundColor(titleBackgroundColor);
+        if (label != null) {
+            label.setBackgroundColor(titleBackgroundColor);
         }
     }
 


### PR DESCRIPTION
Previously when programmatically setting the label background color via `setTitleBackgroundColor` the background of the content TextView was changed instead the CardView's background. This caused some glitches on dark background colors when corner radius was set.
Setting the background color via xml attribute was already working correctly (it uses the CardView's background).

fixes #16