### PR TITLE
Fix for #27: Exception in API < 20 when loading plus vector

### DIFF
--- a/library/src/main/java/jahirfiquitiva/libs/fabsmenu/FABsMenuLayout.java
+++ b/library/src/main/java/jahirfiquitiva/libs/fabsmenu/FABsMenuLayout.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.CoordinatorLayout;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -34,6 +35,7 @@ import android.widget.FrameLayout;
 @CoordinatorLayout.DefaultBehavior(FABSnackbarBehavior.class)
 public class FABsMenuLayout extends FrameLayout {
 
+    private static final String TAG = FABsMenuLayout.class.getSimpleName();
     @ColorInt
     private int overlayColor;
     private View overlayView;
@@ -56,25 +58,27 @@ public class FABsMenuLayout extends FrameLayout {
     }
 
     private void init(Context context, AttributeSet attrs) {
+        TypedArray attr = context.getTheme().obtainStyledAttributes(attrs,
+                R.styleable.FABsMenuLayout, 0,
+                0);
         try {
-            TypedArray a = context.getTheme().obtainStyledAttributes(attrs,
-                                                                     R.styleable.FABsMenuLayout, 0,
-                                                                     0);
-            overlayColor = a.getColor(R.styleable.FABsMenuLayout_fabs_menu_overlayColor,
+            overlayColor = attr.getColor(R.styleable.FABsMenuLayout_fabs_menu_overlayColor,
                                       Color.parseColor("#4d000000"));
-            clickableOverlay = a.getBoolean(R.styleable.FABsMenuLayout_fabs_menu_clickableOverlay,
+            clickableOverlay = attr.getBoolean(R.styleable.FABsMenuLayout_fabs_menu_clickableOverlay,
                                             true);
-            a.recycle();
-
-            overlayView = new View(context);
-            overlayView.setLayoutParams(new FrameLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
-            overlayView.setBackgroundColor(overlayColor);
-            overlayView.setVisibility(View.GONE);
-            addView(overlayView);
         } catch (Exception e) {
-            e.printStackTrace();
+            Log.e(TAG, "Failure setting MenuButton icon", e);
+        }finally {
+            attr.recycle();
         }
+
+        overlayView = new View(context);
+        overlayView.setLayoutParams(new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        overlayView.setBackgroundColor(overlayColor);
+        overlayView.setVisibility(View.GONE);
+        addView(overlayView);
+
     }
 
     @ColorInt

--- a/library/src/main/java/jahirfiquitiva/libs/fabsmenu/TitleFAB.java
+++ b/library/src/main/java/jahirfiquitiva/libs/fabsmenu/TitleFAB.java
@@ -30,6 +30,7 @@ import android.support.v4.view.ViewCompat;
 import android.support.v4.view.animation.FastOutLinearInInterpolator;
 import android.support.v4.view.animation.LinearOutSlowInInterpolator;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 import android.view.animation.Interpolator;
 
@@ -51,6 +52,7 @@ public class TitleFAB extends FloatingActionButton {
     private static final int ANIM_STATE_NONE = 0;
     private static final int ANIM_STATE_HIDING = 1;
     private static final int ANIM_STATE_SHOWING = 2;
+    private static final String TAG = TitleFAB.class.getSimpleName();
 
     int mAnimState = ANIM_STATE_NONE;
 
@@ -80,26 +82,28 @@ public class TitleFAB extends FloatingActionButton {
     }
 
     void init(Context context, AttributeSet attributeSet) {
+        TypedArray attr =
+                context.obtainStyledAttributes(attributeSet, R.styleable.TitleFAB, 0, 0);
         try {
-            TypedArray attr =
-                    context.obtainStyledAttributes(attributeSet, R.styleable.TitleFAB, 0, 0);
             title = attr.getString(R.styleable.TitleFAB_fab_title);
             titleClickEnabled = attr.getBoolean(R.styleable.TitleFAB_fab_enableTitleClick, true);
             titleBackgroundColor = attr.getInt(R.styleable.TitleFAB_fab_title_backgroundColor,
-                                               ContextCompat
-                                                       .getColor(context, android.R.color.white));
+                    ContextCompat
+                            .getColor(context, android.R.color.white));
             titleTextColor = attr.getInt(R.styleable.TitleFAB_fab_title_textColor,
-                                         ContextCompat.getColor(context, android.R.color.black));
+                    ContextCompat.getColor(context, android.R.color.black));
             titleCornerRadius =
                     attr.getDimensionPixelSize(R.styleable.TitleFAB_fab_title_cornerRadius, -1);
             titleTextPadding =
                     attr.getDimensionPixelSize(R.styleable.TitleFAB_fab_title_textPadding,
-                                               (int) DimensionUtils.convertDpToPixel(8, context));
-            setSize(FloatingActionButton.SIZE_MINI);
+                            (int) DimensionUtils.convertDpToPixel(8, context));
+        } catch (Exception e) {
+            Log.w(TAG, "Failure reading attributes", e);
+        } finally {
             attr.recycle();
-            setOnClickListener(null);
-        } catch (Exception ignored) {
         }
+        setOnClickListener(null);
+        setSize(FloatingActionButton.SIZE_MINI);
     }
 
     @Override
@@ -207,7 +211,7 @@ public class TitleFAB extends FloatingActionButton {
         LabelView label = getLabelView();
         if (label != null && label.getContent() != null) {
             label.getContent().setPadding(titleTextPadding, titleTextPadding / 2, titleTextPadding,
-                                          titleTextPadding / 2);
+                    titleTextPadding / 2);
         }
     }
 


### PR DESCRIPTION
<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

### Description
This PR fix #27. The problem was to try to retrieve the Drawable on API < 20 without using the `VectorDrawableCompat`.
This PR also prevent future NPE due to errors during the parsing of the View attributes.

### Motivation
Check #27 for detail on how to reproduce it.